### PR TITLE
include pacman::p_load and .Rhistory in searches

### DIFF
--- a/R/pkgs-use-most.R
+++ b/R/pkgs-use-most.R
@@ -22,12 +22,14 @@ pkg_use <- function(...) {
 
 read_r_files <- function(...) {
   dirs <- list(...)
-  r <- unlist(lapply(dirs, list.files, pattern = "\\.(R|Rmd|Rmarkdown|rmd|r)$",
+  r <- unlist(lapply(dirs, list.files, pattern = "\\.(R|Rmd|Rmarkdown|rmd|r|Rhistory)$",
     recursive = TRUE,
-    full.names = TRUE))
+    full.names = TRUE,
+    all.files = TRUE))
   suppressWarnings( x <- unlist(lapply(r, tfse::readlines)))
   x
 }
+
 
 parse_r_pkgs <- function(x) {
   ## via pkg::
@@ -39,7 +41,10 @@ parse_r_pkgs <- function(x) {
     ## via requireNamespace('pkg')
     tfse::regmatches_(x, "(?<=requireNamespace\\(')[A-Za-z][[:alnum:]\\.]+(?=\\')", drop = TRUE),
     ## via requireNamespace("pkg")
-    tfse::regmatches_(x, "(?<=requireNamespace\\(\")[A-Za-z][[:alnum:]\\.]+(?=\\\")", drop = TRUE))
+    tfse::regmatches_(x, "(?<=requireNamespace\\(\")[A-Za-z][[:alnum:]\\.]+(?=\\\")", drop = TRUE),
+    ## via pacman::p_load("pkg")
+    tfse::regmatches_(x, "(?<=p_load\\()[A-Za-z][[:alnum:]\\, ]+(?=\\))", drop = TRUE) %>%
+      strsplit(",") %>%  unlist() %>% trimws())
 }
 
 arrange_and_factor <- function(.x, cat, val) {

--- a/R/pkgs-use-most.R
+++ b/R/pkgs-use-most.R
@@ -4,8 +4,8 @@
 #' Take inventory of your own package use
 #'
 #' @param ... Directory location in which files ending in '.R' and '.Rmd' will
-#'   be searched for packages (via fully qualified namespace or calls to library
-#'   or require).
+#'   be searched for packages (via fully qualified namespace, calls to library
+#'   or require and also pacman::p_load). In addition, '.Rhistory' will also be searched for packages.
 #' @return A pkguse object, which is really just a tibble with specialized
 #'   methods for plot and summary.
 #' @export

--- a/man/pkg_use.Rd
+++ b/man/pkg_use.Rd
@@ -8,8 +8,8 @@ pkg_use(...)
 }
 \arguments{
 \item{...}{Directory location in which files ending in '.R' and '.Rmd' will
-be searched for packages (via fully qualified namespace or calls to library
-or require).}
+be searched for packages (via fully qualified namespace, calls to library
+or require and also pacman::p_load). In addition, '.Rhistory' will also be searched for packages.}
 }
 \value{
 A pkguse object, which is really just a tibble with specialized


### PR DESCRIPTION
Hi!

So I made two little updates so packages are also recognized when they are loaded via pacman::p_load and `read_r_files` now also looks for `.Rhistory`.